### PR TITLE
fix(vercel): replace legacy routes with modern rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,26 +10,26 @@
       "memory": 1024
     }
   },
-  "routes": [
+  "rewrites": [
     {
-      "src": "/health",
-      "dest": "/api/index.py"
+      "source": "/health",
+      "destination": "/api/index.py"
     },
     {
-      "src": "/search",
-      "dest": "/api/index.py"
+      "source": "/search",
+      "destination": "/api/index.py"
     },
     {
-      "src": "/mcp/stream",
-      "dest": "/api/index.py"
+      "source": "/mcp/stream",
+      "destination": "/api/index.py"
     },
     {
-      "src": "/metrics",
-      "dest": "/api/index.py"
+      "source": "/metrics",
+      "destination": "/api/index.py"
     },
     {
-      "src": "/(.*)",
-      "dest": "/api/index.py"
+      "source": "/(.*)",
+      "destination": "/api/index.py"
     }
   ],
   "env": {


### PR DESCRIPTION
- Convert legacy 'routes' configuration to modern 'rewrites' format
- Resolves Vercel deployment error about conflicting configuration
- Maintains identical routing functionality for all API endpoints
- Fixes compatibility issue with trailingSlash setting

Task: Vercel deployment fix