### PR TITLE
Fix database connection error - asyncpg URL format issue

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -332,7 +332,7 @@ class TestGetPool:
 
             assert result == mock_pool
             mock_create.assert_called_once_with(
-                "postgresql+asyncpg://user:pass@host:5432/db",
+                "postgresql://user:pass@host:5432/db",
                 min_size=0,
                 max_size=5,
                 command_timeout=30,
@@ -360,7 +360,7 @@ class TestGetPool:
 
             assert result == mock_pool
             mock_create.assert_called_once_with(
-                "postgresql+asyncpg://user:pass@host:5432/db",
+                "postgresql://user:pass@host:5432/db",
                 min_size=2,
                 max_size=10,
                 command_timeout=30,


### PR DESCRIPTION
## Summary

- Fixes database connection error where asyncpg.create_pool() was receiving SQLAlchemy-style URLs with driver specifications
- Resolves issue #10 by adding proper URL conversion for asyncpg compatibility

## Root Cause

The `get_pool()` function was passing SQLAlchemy URLs (e.g., `postgresql+asyncpg://...`) directly to `asyncpg.create_pool()`, which only accepts plain PostgreSQL URLs (e.g., `postgresql://...`).

## Changes Made

### Core Fix
- **Added** `_asyncpg_url_from_sqlalchemy()` helper function to convert SQLAlchemy URLs to plain asyncpg-compatible URLs
- **Updated** `get_pool()` to use this helper before calling `asyncpg.create_pool()`

### Files Modified
- `readwise_vector_db/db/__init__.py`: Added helper function and updated pool creation logic
- `tests/test_database.py`: Updated test expectations to reflect correct behavior

## Testing

- All database tests pass (26/26)
- Helper function handles various URL formats correctly:
  - `postgresql+asyncpg://...` → `postgresql://...`
  - `postgresql+psycopg://...` → `postgresql://...`
  - `postgresql://...` → `postgresql://...` (no change)

## Test Plan

- [x] Run database tests to verify fix
- [x] Test helper function with various URL formats
- [x] Verify SQLAlchemy operations still work correctly
- [x] Confirm asyncpg connections work without errors

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection handling to ensure compatibility with asyncpg by standardizing database URLs.

* **Tests**
  * Updated tests to verify that database URLs are correctly formatted for asyncpg connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->